### PR TITLE
fix GoogleDriveSearchTool openai.BadRequestError: Error code: 400

### DIFF
--- a/langchain_googledrive/tools/google_drive/tool.py
+++ b/langchain_googledrive/tools/google_drive/tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class GoogleDriveSearchTool(BaseTool):
     """Tool that adds the capability to query the Google Drive search API."""
 
-    name: str = "Google Drive Search"
+    name: str = "google_drive_search"
     description: str = (
         "A wrapper around Google Drive Search. "
         "Useful for when you need to find a document in google drive. "


### PR DESCRIPTION
Fix GoogleDriveSearchTool openai.BadRequestError: Error code: 400

``` 
{'error': {'message': "'Google Drive Search' does not match '^[a-zA-Z0-9_-]{1,64}$' - 'tools.0.function.name'", 'type': 'invalid_request_error', 'param': None, 'code': None}}
```

It seems that the OpenAI API now checks function name strictly.
So I changed the function name to pass this strict check.